### PR TITLE
refactor: Create New TCP/WS client on every App conn request

### DIFF
--- a/backend/utils/DanmakuHime/BiliBiliHime.js
+++ b/backend/utils/DanmakuHime/BiliBiliHime.js
@@ -1,5 +1,5 @@
 const NetworkLayer = require('./networkLayer')
-const { Header_Fields } = require('./constants')
+const { Header_Fields, CONNECTION_WEBSOCKET, BILIBILI_DANMAKU_SERVER } = require('./constants')
 
 class BiliBiliHime extends NetworkLayer {
   constructor() {
@@ -20,7 +20,16 @@ class BiliBiliHime extends NetworkLayer {
         [Header_Fields["cmd"]]: 4,
         [Header_Fields["unknown-4"]]: 4
       },
-      isLittleEndiness: false
+      defaults: {
+        [Header_Fields["encrypt"]]: 0,
+        [Header_Fields["reserve"]]: 0,
+        [Header_Fields["cmd"]]: 689
+      },
+      isLittleEndiness: true,
+      connection: {
+        type: CONNECTION_WEBSOCKET,
+        host: BILIBILI_DANMAKU_SERVER
+      }
     })
   }
 }

--- a/backend/utils/DanmakuHime/DouyuHime.js
+++ b/backend/utils/DanmakuHime/DouyuHime.js
@@ -106,6 +106,7 @@ class DouyuHime extends NetworkLayer {
     const roomID = url.match(roomIDReg)[1]
     if (roomID === undefined) throw new Error("Invalid Douyu URL")
     try {
+      await this.createConnection()
       await this.login(roomID, options)
       console.log(Session_Events["connect:succeed"])
       this.emit(Session_Events["connect:succeed"])

--- a/backend/utils/DanmakuHime/constants.js
+++ b/backend/utils/DanmakuHime/constants.js
@@ -13,7 +13,9 @@ const Session_Events = {
 }
 
 const Network_Events = {
-  "pkg": "Network:package:received"
+  "pkg": "Network:package:received",
+  "connect:succeed": "Network:connect:succeed",
+  "connect:failed": "Network:connect:failed"
 }
 
 const Header_Fields = {
@@ -31,11 +33,14 @@ const Header_Fields = {
 const CONNECTION_TCP = "tcp"
 const CONNECTION_WEBSOCKET = "websocket"
 
+const BILIBILI_DANMAKU_SERVER = "wss://tx-bj4-live-comet-05.chat.bilibili.com/sub"
+
 module.exports = {
   DanmakuHime_Events,
   Session_Events,
   Network_Events,
   Header_Fields,
   CONNECTION_TCP,
-  CONNECTION_WEBSOCKET
+  CONNECTION_WEBSOCKET,
+  BILIBILI_DANMAKU_SERVER
 }


### PR DESCRIPTION
The session Layer will create an new TCP/WS client and connect to target
url, instead of connecting at the very beginning time with only one client.

pros:
1. Can change target url on demand, such as the available danmaku server return by an ajax server.
2. Can easily use await operator to wait for the succeed connection, avoiding the potential risk that following operation is executed before connection succeed.